### PR TITLE
feat: add WithAllocator option to QueryRequest

### DIFF
--- a/iox_client_test.go
+++ b/iox_client_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/apache/arrow/go/arrow/array"
+	"github.com/apache/arrow/go/arrow/memory"
 	"github.com/influxdata/influxdb-iox-client-go"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +67,7 @@ func TestClient(t *testing.T) {
 
 	req, err := client.PrepareQuery(ctx, "", "select count(*) from t;")
 	require.NoError(t, err)
+	req = req.WithAllocator(memory.DefaultAllocator)
 
 	reader, err := req.Query(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
Flux's runtime uses Arrow's `memory.Allocator` interface to keep track of memory allocated in Arrow arrays. This change allows the IOx Go client to accept an allocator to this end.