### PR TITLE
fix: create query requests with a default allocator

### DIFF
--- a/iox_client_query.go
+++ b/iox_client_query.go
@@ -64,9 +64,10 @@ type QueryRequest struct {
 
 func newRequest(client *Client, database, query string) *QueryRequest {
 	return &QueryRequest{
-		client:   client,
-		database: database,
-		query:    query,
+		client:    client,
+		database:  database,
+		query:     query,
+		allocator: memory.DefaultAllocator,
 	}
 }
 


### PR DESCRIPTION
A recent change to Arrow seems to require a non-nil allocator when
reading records off the wire. So this change just ensures we provide
a default allocator.

Fixes #16.