### PR TITLE
fix: Switch instructions to run NG IOx

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project does not run tests as part of CI.
 Most tests depend on a running instance of InfluxDB/IOx, and each creates its own database.
 To start an in-memory instance, from the [InfluxDB/IOx repository](https://github.com/influxdata/influxdb_iox/) root:
 ```console
-$ INFLUXDB_IOX_ID=42 cargo run -- run
+$ cargo run
 ```
 
 Then run the tests like any golang test:


### PR DESCRIPTION
Fixes https://github.com/influxdata/influxdb_iox/issues/4412.

Depends on https://github.com/influxdata/influxdb-iox-client-go/pull/25 and https://github.com/influxdata/influxdb_iox/pull/4463.