### PR TITLE
test: fix data types

### DIFF
--- a/iox_client_ingester_writeinfo_test.go
+++ b/iox_client_ingester_writeinfo_test.go
@@ -2,15 +2,16 @@ package influxdbiox_test
 
 import (
 	"context"
-	"github.com/apache/arrow/go/v7/arrow/array"
-	influxdbiox "github.com/influxdata/influxdb-iox-client-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/textproto"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/apache/arrow/go/v7/arrow/array"
+	influxdbiox "github.com/influxdata/influxdb-iox-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteTokenFromHTTPResponse(t *testing.T) {
@@ -72,6 +73,6 @@ func TestClient_WaitForReadable(t *testing.T) {
 
 	require.True(t, reader.Next())
 	record := reader.Record()
-	assert.Equal(t, []uint64{10}, record.Column(0).(*array.Uint64).Uint64Values())
+	assert.Equal(t, []int64{10}, record.Column(0).(*array.Int64).Int64Values())
 	require.False(t, reader.Next())
 }

--- a/iox_client_test.go
+++ b/iox_client_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"google.golang.org/grpc"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/apache/arrow/go/v7/arrow/array"
 	influxdbiox "github.com/influxdata/influxdb-iox-client-go"
@@ -102,6 +103,6 @@ func TestClient(t *testing.T) {
 
 	for reader.Next() {
 		record := reader.Record()
-		t.Logf("%v", record.Column(0).(*array.Uint64).Uint64Values())
+		t.Logf("%v", record.Column(0).(*array.Int64).Int64Values())
 	}
 }


### PR DESCRIPTION
While running `cargo run` in one terminal running IOx HEAD (`106d84c6e1808eabd52f4446f65f556298981f98`) and running `go test ./...` (again, on HEAD) in another terminal, these two tests failed due to mismatched data types in the response.

```
--- FAIL: TestClient_WaitForReadable (0.52s)
panic: interface conversion: arrow.Array is *array.Int64, not *array.Uint64 [recovered]
	panic: interface conversion: arrow.Array is *array.Int64, not *array.Uint64

goroutine 11 [running]:
testing.tRunner.func1.2({0x102bc0920, 0x14000310ba0})
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1392 +0x384
panic({0x102bc0920, 0x14000310ba0})
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:838 +0x204
github.com/influxdata/influxdb-iox-client-go_test.TestClient_WaitForReadable(0x140001c8820)
	/Users/dom/influx/influxdb-iox-client-go/iox_client_ingester_writeinfo_test.go:75 +0x33c
testing.tRunner(0x140001c8820, 0x102c715e0)
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1486 +0x300
```

and

```
--- FAIL: TestClient (0.01s)
panic: interface conversion: arrow.Array is *array.Int64, not *array.Uint64 [recovered]
	panic: interface conversion: arrow.Array is *array.Int64, not *array.Uint64

goroutine 36 [running]:
testing.tRunner.func1.2({0x10311c8c0, 0x140002c6900})
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1392 +0x384
panic({0x10311c8c0, 0x140002c6900})
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/runtime/panic.go:838 +0x204
github.com/influxdata/influxdb-iox-client-go_test.TestClient(0x1400030a340)
	/Users/dom/influx/influxdb-iox-client-go/iox_client_test.go:105 +0x258
testing.tRunner(0x1400030a340, 0x1031cd588)
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/Cellar/go/1.18.3/libexec/src/testing/testing.go:1486 +0x300
```

---

* test: fix data types (f8aaf51)

      Updates the tests to pass with the latest IOx builds.

      While I'm not sure why these were using unsigned values previously, the 
      writeDataset() writes signed int64 values, and the arrow stream returns data
      typed as int64.