### PR TITLE
fix: payload check to be cloud compatible

### DIFF
--- a/iox_client_query.go
+++ b/iox_client_query.go
@@ -32,7 +32,7 @@ func (c *Client) Handshake(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if !bytes.Equal(resp.Payload, payload) {
+	if !bytes.Equal(resp.Payload, payload) && resp.Payload != nil {
 		return errors.New("handshake payload response does not match request")
 	}
 	return nil


### PR DESCRIPTION
Closes #56 .
Possibly skip payload check if it's nil in order to support the cloud instances.